### PR TITLE
Allow update-local independently of pr

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Comma separted list of checks to ignore.
 
 Create a pull request to bring local records in line with remote records (defaults to `false`)
 
+### `update-local`
+
+Update local records and reservations to match the remote state (e.g. writing back server-populated metadata).
+
+When left empty this defaults to the value of `pr`, preserving the previous behavior. Set it to `true` to update the local files without creating a pull request, for example if you want to create the PR yourself in a later step. (Defaults to the value of `pr`)
+
 ### `github-token`
 
 A github token to be used by this action. Default ` `. Recommended value: ${{ secrets.GITHUB_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,9 @@ inputs:
   pr:
     description: 'Create a PR to bring local records in line with remote records.'
     default: false
+  update-local:
+    description: 'Update local records/reservations to match remote state. Defaults to the value of `pr` when left empty, so set it to `true` to update local files without creating a PR.'
+    default: ''
   github-token :
     description: 'Github token, usually automatically provided via `secrets.GITHUB_TOKEN`, required when pr is set to `true`'
   github-branch :
@@ -87,6 +90,7 @@ runs:
     MIN_RESERVED :          ${{ inputs.min-reserved }}
     RESERVE :               ${{ inputs.reserve }}
     DO_PR :                 ${{ inputs.pr }}
+    UPDATE_LOCAL_INPUT :    ${{ inputs.update-local }}
     INCLUDE_RESERVATIONS :  ${{ inputs.check-reservations }}
     RESERVATIONS_PATH :     ${{ inputs.reservations-path }}
     CREATE_MISSING :        ${{ inputs.create-missing }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,7 @@
 #    MIN_RESERVED :          ${{ inputs.min-reserved }}
 #    RESERVE :     		     ${{ inputs.reserve }}
 #    DO_PR :                 ${{ inputs.pr }}
+#    UPDATE_LOCAL_INPUT :    ${{ inputs.update-local }}
 #    INCLUDE_RESERVATIONS :  ${{ inputs.check-reservations }}
 #    RESERVATIONS_PATH :     ${{ inputs.reservations-path }}
 #    CREATE_MISSING : 	     ${{ inpouts.create-missing }}
@@ -57,7 +58,12 @@ if [[ "$RESERVE" != "" ]]; then
 	RESERVE="--reserve $RESERVE"
 fi
 
-if [[ "$DO_PR" == "true" ]]; then
+# Update local records to match remote state. When update-local is not
+# explicitly set, it defaults to the value of pr (the previous behavior).
+if [[ -z "$UPDATE_LOCAL_INPUT" ]]; then
+	UPDATE_LOCAL_INPUT="$DO_PR"
+fi
+if [[ "$UPDATE_LOCAL_INPUT" == "true" ]]; then
 	UPDATE_LOCAL="--update-local"
 fi
 


### PR DESCRIPTION
Previously local records and reservations were only synced to remote state (--update-local) when pr was true, since entrypoint.sh derived the flag solely from DO_PR. This made it impossible to update local files without also having the action open a PR.

Add an explicit update-local input. When left empty it defaults to the value of pr, preserving existing behavior; set it to true to update the local files without creating a PR (e.g. to create the PR yourself in a later step). Wired through action.yml (input + env) and entrypoint.sh, and documented in the README.