### PR TITLE
Read back server state after first publish

### DIFF
--- a/program/cve_publish_update.py
+++ b/program/cve_publish_update.py
@@ -143,6 +143,18 @@ if __name__ == '__main__':
                         else:
                             print(result["message"])
                             created=created+1
+                            # Publishing populates server-side fields (e.g. datePublished,
+                            # providerMetadata). Read them back so the local record reflects
+                            # the new state in the same run instead of on the next one.
+                            if args.update_local :
+                                cve_record = cve_api.show_cve_record(cve_id)
+                                diff = DeepDiff(
+                                    cve_record,
+                                    json_data
+                                )
+                                if diff != {} :
+                                    write_json_file(filename, cve_record)
+                                    print("Updated local records of {} with remote (meta-)data.".format(cve_id))
 
 
                     if file_valid and cve_metadata["state"] == "PUBLISHED" and json_data["cveMetadata"]["state"] == "PUBLISHED":


### PR DESCRIPTION
When a record was published (RESERVED -> PUBLISHED), the server-populated fields (datePublished, providerMetadata, ...) were never written back to the local file. With --update-local set, that read-back only happened in the PUBLISHED -> PUBLISHED branch, which is skipped on the publishing run because the metadata was fetched while the record was still RESERVED.

As a result, after merging to main the publish would succeed but leave the working tree clean, so no PR was opened. The PR only appeared on a later run once the server reported PUBLISHED. Now we re-fetch and write the record back in the same run that publishes it, so the PR is created directly.