### PR TITLE
Add delete-rejected switch for rejected reservations

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ Example values are:
 * `2m` for 2 months, reservations will expire on or after 1 Mar
 * `1y` for 1 year, reserveration will expire on or after 1 Jan for reservations before the previous year
 
+### `delete-rejected`
+
+Controls what happens to the local file of a reservation that is rejected (either explicitly, or because it expired via `expire-after`).
+
+* `false` (default): keep the local file and set its state to `REJECTED`.
+* `true`: delete the local file instead.
+
 ### `skip-cve-lint`
 
 Set to `true` to skip running cvelint validation checks. (Defaults to `false`)

--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,9 @@ inputs:
   expire-after:
     description: 'Create PR to expire reservations this much time after the end of the year (e.g 4d, 3w, 2m or 1y)'
     default: ''
+  delete-rejected:
+    description: 'Delete the local file of a rejected reservation instead of keeping it with state REJECTED (default: false)'
+    default: false
   verbose :
     description: 'Verbose output'
     default: false
@@ -91,6 +94,7 @@ runs:
     RESERVATIONS_PATH :     ${{ inputs.reservations-path }}
     CREATE_MISSING :        ${{ inputs.create-missing }}
     EXPIRE_AFTER :          ${{ inputs.expire-after }}
+    DELETE_REJECTED :       ${{ inputs.delete-rejected }}
     VERBOSE :               ${{ inputs.verbose }}
     QUIET :                 ${{ inputs.quiet }}
     DEBUG:                  ${{ inputs.debug }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,6 +17,7 @@
 #    RESERVATIONS_PATH :     ${{ inputs.reservations-path }}
 #    CREATE_MISSING : 	     ${{ inpouts.create-missing }}
 #    EXPIRE_AFTER :          ${{ inputs.expire-after }}
+#    DELETE_REJECTED :       ${{ inputs.delete-rejected }}
 #    SKIP_CVE_LINT :        ${{ inputs.skip-cve-lint }}
 
 
@@ -84,6 +85,10 @@ if [[ $( echo $RESERVATIONS_PATH | egrep "^\/" | wc -l ) -gt 0 ]] ; then
 fi
 if [[ ! -z "$EXPIRE_AFTER" ]]; then
 	EXPIRE="--expire-after $EXPIRE_AFTER"
+fi
+
+if [[ "$DELETE_REJECTED" == "true" ]]; then
+	DELETE_REJECTED_FLAG="--delete-rejected"
 fi
 
 if [[ "$QUIET" == "true" ]]; then
@@ -179,7 +184,7 @@ fi
 if [[ "$CVE_PUBLISH" == "true" ]]; then
 	echo
 	echo "*** Publishing/updating CVE records ***"
-	CMD="/run/cve_publish_update.py --path $CVE_PATH $UPDATE_LOCAL $RESERVATIONS_TOO $DO_RESERVATIONS $EXPIRE"
+	CMD="/run/cve_publish_update.py --path $CVE_PATH $UPDATE_LOCAL $RESERVATIONS_TOO $DO_RESERVATIONS $EXPIRE $DELETE_REJECTED_FLAG"
 	echo "Running: $CMD"
 	$CMD | tee /tmp/publish.log
 

--- a/program/cve_publish_update.py
+++ b/program/cve_publish_update.py
@@ -47,6 +47,7 @@ if __name__ == '__main__':
     parser.add_argument('--include-reservations', action="store_true", default=False, help="Include reservations")
     parser.add_argument('--reservations-path', type=str, metavar=".", default="", help="path of directory to check")
     parser.add_argument('--expire-after', type=str, metavar="3M", default="", help="Expire reservations time much after the year has expired via a pull-request, date can be specified as w.g. 30d, 3w, 2m or 1y (default: don't expire)")
+    parser.add_argument('--delete-rejected', action="store_true", default=False, help="Delete the local file of a rejected reservation instead of keeping it with state REJECTED")
 
     args = parser.parse_args()
 
@@ -284,7 +285,7 @@ if __name__ == '__main__':
                         reserved[cve_id]["state"] = "REJECTED"
                         updated=updated+1
 
-                    if file_valid and args.update_local :
+                    if file_valid and args.update_local and not (args.delete_rejected and reserved[cve_id]["state"] == "REJECTED") :
                         diff = DeepDiff(
                             reserved[cve_id],
                             json_data
@@ -300,9 +301,15 @@ if __name__ == '__main__':
                         result = re.search(r"^CVE\-(\d{4})\-", cve_id)
                         if int(result.group(1)) <= expire_year :
                             reserved[cve_id]["state"] = "REJECTED"
-                            write_json_file(filename, reserved[cve_id])
+                            if not args.delete_rejected :
+                                write_json_file(filename, reserved[cve_id])
                             print("Local reservation for {} updated to expire reservation.".format(cve_id))
                             expired = expired + 1
+
+                    # Delete the local file of a rejected reservation if requested
+                    if file_valid and args.delete_rejected and reserved[cve_id]["state"] == "REJECTED" :
+                        os.remove(filename)
+                        print("Deleted local record for rejected reservation {}.".format(cve_id))
 
                     if file_valid:
                         del reserved[cve_id]
@@ -310,6 +317,9 @@ if __name__ == '__main__':
         # Write reservations we don't have locally
         for cve_id in sorted(reserved):
             if cve_id != "INVALID" :
+                if args.delete_rejected and reserved[cve_id]["state"] == "REJECTED" :
+                    print("Reservation file for {} does not exist, skipping rejected reservation.".format(cve_id))
+                    continue
                 print("Reservation file for {} does not exist".format(cve_id))
                 write_json_file("{}/{}.json".format(args.reservations_path,cve_id),reserved[cve_id])
                 print("Created {}/{}.json".format(args.reservations_path,cve_id))


### PR DESCRIPTION
Introduce a delete-rejected option to control what happens to the local file of a reservation that becomes REJECTED, either explicitly or via expire-after:

* false (default): keep the file and set its state to REJECTED (current behavior, backward-compatible)
* true: delete the local file instead

Wired through action.yml (input + env), entrypoint.sh (--delete-rejected flag), and cve_publish_update.py. In delete mode the expire and update-local writes are skipped, and rejected server-only reservations are no longer materialized as new files. Documented in the README.