### PR TITLE
Add --exclude-locked flag for min-reserved count

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Minimum number of reserved records for the current year.
 
 Action will fail if the number of records in RESERVED state drops below this amount. If `reserve` is set to a number above 0 this action will reserve this many new records.
 
+### `exclude-locked`
+
+When set to `true`, CVE IDs listed in `reservations.lock` files are excluded from the `min-reserved` count. Locked reservations are treated as spoken for, so the minimum applies to the pool of unlocked reservations. Defaults to `false`, in which case locked reservations count towards the minimum just like any other RESERVED record.
+
 ### `expire-after`
 
 Create pull request (if `pr` is set to `true`) to expire reservations this much time after the end of the year.

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,9 @@ inputs:
   reserve:
     description: 'Minimum number of records to reserve in one go (0=do not make reservations)'
     default: 0
+  exclude-locked:
+    description: 'Exclude reservations listed in reservations.lock files from the min-reserved count'
+    default: false
   pr:
     description: 'Create a PR to bring local records in line with remote records.'
     default: false
@@ -86,6 +89,7 @@ runs:
     IGNORE_CHECKS :         ${{ inputs.ignore }}
     MIN_RESERVED :          ${{ inputs.min-reserved }}
     RESERVE :               ${{ inputs.reserve }}
+    EXCLUDE_LOCKED :        ${{ inputs.exclude-locked }}
     DO_PR :                 ${{ inputs.pr }}
     INCLUDE_RESERVATIONS :  ${{ inputs.check-reservations }}
     RESERVATIONS_PATH :     ${{ inputs.reservations-path }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,7 @@
 #    IGNORE_CHECKS :         ${{ inputs.ignore }}
 #    MIN_RESERVED :          ${{ inputs.min-reserved }}
 #    RESERVE :     		     ${{ inputs.reserve }}
+#    EXCLUDE_LOCKED :        ${{ inputs.exclude-locked }}
 #    DO_PR :                 ${{ inputs.pr }}
 #    INCLUDE_RESERVATIONS :  ${{ inputs.check-reservations }}
 #    RESERVATIONS_PATH :     ${{ inputs.reservations-path }}
@@ -55,6 +56,11 @@ if [[ "$MIN_RESERVED" != "" ]]; then
 fi
 if [[ "$RESERVE" != "" ]]; then
 	RESERVE="--reserve $RESERVE"
+fi
+if [[ "$EXCLUDE_LOCKED" == "true" ]]; then
+	EXCLUDE_LOCKED="--exclude-locked"
+else
+	EXCLUDE_LOCKED=""
 fi
 
 if [[ "$DO_PR" == "true" ]]; then
@@ -109,7 +115,7 @@ git config --global --add safe.directory $PWD
 echo "*** Checking CVE records ***"
 rm -f /tmp/cve_check.log && touch /tmp/cve_check.log
 CVE_CHECK_FAILED=0
-CMD="/run/cve_check.py --path $CVE_PATH $IGNORE_CHECKS $MIN_RESERVED $RESERVE $RESERVATIONS_TOO $DO_RESERVATIONS $DO_MISSING $VERBOSE_FLAG --log /tmp/cve_check.log"
+CMD="/run/cve_check.py --path $CVE_PATH $IGNORE_CHECKS $MIN_RESERVED $RESERVE $EXCLUDE_LOCKED $RESERVATIONS_TOO $DO_RESERVATIONS $DO_MISSING $VERBOSE_FLAG --log /tmp/cve_check.log"
 echo "Running: $CMD"
 $CMD || CVE_CHECK_FAILED=1
 

--- a/program/cve_check.py
+++ b/program/cve_check.py
@@ -11,6 +11,21 @@ from cvelib.cve_api import CveRecord
 
 # General checks
 
+def locked_reservations(args) :
+    # Collect CVE IDs that are listed in reservations.lock files
+    locked = set()
+    if not os.path.exists(args.reservations_path) :
+        return locked
+    for root, dirs, files in os.walk(args.reservations_path):
+        for file in files:
+            if file == "reservations.lock" :
+                with open(os.path.join(root, file)) as lf:
+                    for line in lf.readlines() :
+                        result = re.search(r"^\s*(CVE\-\d{4}\-\d{4,})?\s*(\#.*)?$", line)
+                        if result and result.group(1) :
+                            locked.add(result.group(1))
+    return locked
+
 def minimum_reserved(args) :
     global cves
     # Check if we have have the minimum number of CVE IDs reserved
@@ -19,9 +34,14 @@ def minimum_reserved(args) :
     if args.min_reserved > 0:
         year = datetime.date.today().year
         num_reserved = 0
+        # Locked reservations may be spoken for and excluded from the minimum
+        if args.exclude_locked:
+            locked = locked_reservations(args)
+        else:
+            locked = set()
         reserved = []
         for cve in cves:
-            if cve["state"] == "RESERVED" and cve["cve_year"] == str(year) :
+            if cve["state"] == "RESERVED" and cve["cve_year"] == str(year) and cve["cve_id"] not in locked :
                 reserved.append(cve)
         if len(reserved) < args.min_reserved:
             if args.reserve > 0:
@@ -394,6 +414,7 @@ if __name__ == '__main__':
     parser.add_argument('--list', action="count", default=0, help="list all checks and exit" )
     parser.add_argument('--min-reserved', type=int, metavar="N", default=0, help="Minimum number of reserved IDs for the current year" )
     parser.add_argument('--reserve', type=int, metavar="N", default=0, help="Reserve N new entries if reserved for this year is below minimum")
+    parser.add_argument('--exclude-locked', action="store_true", default=False, help="Exclude reservations listed in reservations.lock files from the min-reserved count")
     parser.add_argument('--include-reservations', action="store_true", default=False, help="Include reservations in our records")
     parser.add_argument('--reservations-path', type=str, metavar="./reservations", default="", help="path of directory for reservations")
     parser.add_argument('--create-missing', action="store_true", default=False, help="Create cve records from cve databazse when missing")


### PR DESCRIPTION
The minimum_reserved check counted every current-year RESERVED CVE ID against --min-reserved, including ones listed in reservations.lock. Locked IDs may be spoken for, so a pool full of locked reservations could suppress topping up the available pool.

Add an opt-in --exclude-locked flag (exclude-locked action input, default false) that excludes IDs found in reservations.lock files from the count via a new locked_reservations helper (reusing the parsing from cve_publish_update.py). Default behavior is unchanged: locked reservations still count towards the minimum.